### PR TITLE
Fix build break

### DIFF
--- a/scripts/Install-CLIv2.ps1
+++ b/scripts/Install-CLIv2.ps1
@@ -34,3 +34,9 @@ $Env:AZURE_ML_CLI_PRIVATE_FEATURES_ENABLED=$true
 
 # Check the commands
 az ml -h
+
+
+# Show the version
+Write-Host
+Write-Host "Info about ml extension:"
+az extension show --name ml

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@
 import json
 import pytest
 
+from azure.identity import DefaultAzureCredential
 from azure.ml import MLClient
 
 
@@ -29,9 +30,10 @@ def workspace_config():
 @pytest.fixture(scope='function')
 def ml_client(workspace_config):
     client = MLClient(
-        workspace_config['subscription_id'],
-        workspace_config['resource_group'],
-        workspace_config['workspace_name'],
+        credential=DefaultAzureCredential(),
+        subscription_id=workspace_config['subscription_id'],
+        resource_group_name=workspace_config['resource_group'],
+        workspace_name=workspace_config['workspace_name'],
         logging_enable=True
     )
 

--- a/test/rai/pipeline_adult_analyse.yaml
+++ b/test/rai/pipeline_adult_analyse.yaml
@@ -13,14 +13,14 @@ inputs:
 
 outputs:
   my_model_directory:
-    data:
-      datastore: azureml:workspaceblobstore
+    datastore: azureml:workspaceblobstore
+    mode: upload
   ma_info:
-    data:
-      datastore: azureml:workspaceblobstore
+    datastore: azureml:workspaceblobstore
+    mode: upload
   model_info:
-    data:
-      datastore: azureml:workspaceblobstore
+    datastore: azureml:workspaceblobstore
+    mode: upload
 
 compute: azureml:cpucluster
 

--- a/test/rai/pipeline_adult_analyse.yaml
+++ b/test/rai/pipeline_adult_analyse.yaml
@@ -13,13 +13,13 @@ inputs:
 
 outputs:
   my_model_directory:
-    datastore: azureml:workspaceblobstore
+    # datastore: azureml:workspaceblobstore
     mode: upload
   ma_info:
-    datastore: azureml:workspaceblobstore
+    # datastore: azureml:workspaceblobstore
     mode: upload
   model_info:
-    datastore: azureml:workspaceblobstore
+    # datastore: azureml:workspaceblobstore
     mode: upload
 
 compute: azureml:cpucluster

--- a/test/rai/pipeline_boston_analyse.yaml
+++ b/test/rai/pipeline_boston_analyse.yaml
@@ -13,14 +13,14 @@ inputs:
 
 outputs:
   my_model_directory:
-    data:
-      datastore: azureml:workspaceblobstore
+    # datastore: azureml:workspaceblobstore
+    mode: upload
   ma_info:
-    data:
-      datastore: azureml:workspaceblobstore
+    # datastore: azureml:workspaceblobstore
+    mode: upload
   model_info:
-    data:
-      datastore: azureml:workspaceblobstore
+    # datastore: azureml:workspaceblobstore
+    mode: upload
 
 compute: azureml:cpucluster
 

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -6,7 +6,7 @@ import logging
 import pathlib
 import time
 
-from azure.ml.entities import InputDatasetEntry
+from azure.ml.entities import JobInput
 from azure.ml.entities import ComponentJob, Job, PipelineJob
 
 _logger = logging.getLogger(__file__)
@@ -73,8 +73,8 @@ class TestRAI:
         # Configure the global pipeline inputs:
         pipeline_inputs = {
             'target_column_name': 'income',
-            'my_training_data': InputDatasetEntry(dataset=f"Adult_Train_PQ:{version_string}"),
-            'my_test_data': InputDatasetEntry(dataset=f"Adult_Test_PQ:{version_string}")
+            'my_training_data': JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
+            'my_test_data': JobInput(dataset=f"Adult_Test_PQ:{version_string}")
         }
 
         # Specify the training job


### PR DESCRIPTION
Some breaking changes in latest SDK release. Temporarily turn off datastore designation for component outputs.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>