### PR TITLE
Add component to fetch a registered model

### DIFF
--- a/requirements-dev-releasepackage.txt
+++ b/requirements-dev-releasepackage.txt
@@ -4,5 +4,6 @@ azure-ml
 pandas
 pyarrow
 pytest
+pytest-xdist
 scikit-learn
 shap

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ azure-ml
 pandas
 pyarrow
 pytest
+pytest-xdist
 scikit-learn
 shap

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -5,4 +5,4 @@
 # Enable all the commands
 $Env:AZURE_ML_CLI_PRIVATE_FEATURES_ENABLED=$true
 
-python -m pytest ./test/ -o junit_family=xunit2 --junitxml=junit.xml
+python -m pytest -n auto ./test/ -o junit_family=xunit2 --junitxml=junit.xml

--- a/src/responsibleai/component_fetch_registered_model.yaml
+++ b/src/responsibleai/component_fetch_registered_model.yaml
@@ -9,5 +9,6 @@ inputs:
 outputs:
   model_info_output_path:
     type: path
+environment: azureml:AML-RAI-Environment:VERSION_REPLACEMENT_STRING
 command: >-
   cat "{ 'id' : '${{inputs.model_id}}' }" > ${{outputs.model_info_output_path}}

--- a/src/responsibleai/component_fetch_registered_model.yaml
+++ b/src/responsibleai/component_fetch_registered_model.yaml
@@ -9,6 +9,10 @@ inputs:
 outputs:
   model_info_output_path:
     type: path
+code:
+  local_path: ./src_fetch_registered/
 environment: azureml:AML-RAI-Environment:VERSION_REPLACEMENT_STRING
 command: >-
-  cat "{ \'id\' : \'${{inputs.model_id}}\' }" > ${{outputs.model_info_output_path}}/model_info.json
+  python fetch_registered.py
+  --model_id ${{inputs.model_id}}
+  --model_info_output_path ${{outputs.model_info_output_path}}

--- a/src/responsibleai/component_fetch_registered_model.yaml
+++ b/src/responsibleai/component_fetch_registered_model.yaml
@@ -11,4 +11,4 @@ outputs:
     type: path
 environment: azureml:AML-RAI-Environment:VERSION_REPLACEMENT_STRING
 command: >-
-  cat "{ 'id' : '${{inputs.model_id}}' }" > ${{outputs.model_info_output_path}}/model_info.json
+  cat "{ \'id\' : \'${{inputs.model_id}}\' }" > ${{outputs.model_info_output_path}}/model_info.json

--- a/src/responsibleai/component_fetch_registered_model.yaml
+++ b/src/responsibleai/component_fetch_registered_model.yaml
@@ -11,4 +11,4 @@ outputs:
     type: path
 environment: azureml:AML-RAI-Environment:VERSION_REPLACEMENT_STRING
 command: >-
-  cat "{ 'id' : '${{inputs.model_id}}' }" > ${{outputs.model_info_output_path}}
+  cat "{ 'id' : '${{inputs.model_id}}' }" > ${{outputs.model_info_output_path}}/model_info.json

--- a/src/responsibleai/component_fetch_registered_model.yaml
+++ b/src/responsibleai/component_fetch_registered_model.yaml
@@ -1,0 +1,13 @@
+$schema: http://azureml/sdk-2-0/CommandComponent.json
+name: FetchRegisteredModel
+display_name: Fetch Registered Model
+version: VERSION_REPLACEMENT_STRING
+type: command
+inputs:
+  model_id:
+    type: string
+outputs:
+  model_info_output_path:
+    type: path
+command: >-
+  cat "{ 'id' : '${{inputs.model_id}}' }" > ${{outputs.model_info_output_path}}

--- a/src/responsibleai/component_register_model.yaml
+++ b/src/responsibleai/component_register_model.yaml
@@ -9,6 +9,9 @@ inputs:
     type: path
   model_base_name:
     type: string
+  model_name_suffix: # Set negative to use epoch_secs
+    type: int
+    default: -1
 outputs:
   model_info_output_path:
     type: path
@@ -19,4 +22,5 @@ command: >-
   python register.py
   --model_input_path ${{inputs.model_input_path}}
   --model_base_name ${{inputs.model_base_name}}
+  --model_name_suffix ${{inputs.model_name_suffix}}
   --model_info_output_path ${{outputs.model_info_output_path}}

--- a/src/responsibleai/component_register_model.yaml
+++ b/src/responsibleai/component_register_model.yaml
@@ -10,7 +10,7 @@ inputs:
   model_base_name:
     type: string
   model_name_suffix: # Set negative to use epoch_secs
-    type: int
+    type: integer
     default: -1
 outputs:
   model_info_output_path:

--- a/src/responsibleai/registration_config.json
+++ b/src/responsibleai/registration_config.json
@@ -4,6 +4,7 @@
     ],
     "components" : [
         "component_register_model.yaml",
+        "component_fetch_registered_model.yaml",
         "component_causal.yaml",
         "component_counterfactual.yaml",
         "component_error_analysis.yaml",

--- a/src/responsibleai/src_fetch_registered/fetch_registered.py
+++ b/src/responsibleai/src_fetch_registered/fetch_registered.py
@@ -1,0 +1,47 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+import argparse
+import json
+import os
+
+
+def parse_args():
+    # setup arg parser
+    parser = argparse.ArgumentParser()
+
+    # add arguments
+    parser.add_argument("--model_id", type=str, help="Path to input model")
+    parser.add_argument("--model_info_output_path", type=str,
+                        help="Path to write model info JSON")
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main(args):
+    print("Writing JSON")
+    dict = {"id": "{0}".format(args.model_id)}
+    output_path = os.path.join(args.model_info_output_path, "model_info.json")
+    with open(output_path, "w") as of:
+        json.dump(dict, fp=of)
+    print("Done")
+
+
+# run script
+if __name__ == "__main__":
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")
+
+    # parse args
+    args = parse_args()
+
+    # run main function
+    main(args)
+
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")

--- a/src/responsibleai/src_register/register.py
+++ b/src/responsibleai/src_register/register.py
@@ -27,6 +27,7 @@ def parse_args():
     parser.add_argument("--model_input_path", type=str, help="Path to input model")
     parser.add_argument("--model_info_output_path", type=str, help="Path to write model info JSON")
     parser.add_argument("--model_base_name", type=str, help="Name of the registered model")
+    parser.add_argument("--model_name_suffix", type=int, help="Set negative to use epoch_secs")
 
     # parse args
     args = parser.parse_args()
@@ -45,8 +46,11 @@ def main(args):
     print("Loading model")
     mlflow_model = mlflow.sklearn.load_model(args.model_input_path)
 
-    epoch_secs = int(time.time())
-    registered_name = "{0}_{1}".format(args.model_base_name, epoch_secs)
+    if args.model_name_suffix < 0:
+        suffix = int(time.time())
+    else:
+        suffix = args.model_name_suffix
+    registered_name = "{0}_{1}".format(args.model_base_name, suffix)
     print(f"Registering model as {registered_name}")
 
     print("Registering via MLFlow")

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -68,7 +68,7 @@ class TestRAI:
         submit_and_wait(ml_client, pipeline_job)
 
     def test_classification_pipeline(self, ml_client, component_config):
-        # This only configures an explanation for simplicity
+        # This is for the Adult dataset
         version_string = component_config['version']
 
         # Configure the global pipeline inputs:
@@ -206,3 +206,132 @@ class TestRAI:
         # Send it
         pipeline_job = submit_and_wait(ml_client, pipeline_job)
         assert pipeline_job is not None
+
+    def test_fetch_registered_model_component(self, ml_client, component_config):
+        # Actually does two pipelines. One to register, then one to use
+        version_string = component_config['version']
+
+        model_name_suffix = int(time.time())
+        model_name = 'fetch_model'
+
+        # Configure the global pipeline inputs:
+        pipeline_inputs = {
+            'target_column_name': 'income',
+            'my_training_data': JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
+            'my_test_data': JobInput(dataset=f"Adult_Test_PQ:{version_string}")
+        }
+
+        # Specify the training job
+        train_job_inputs = {
+            'target_column_name': '${{inputs.target_column_name}}',
+            'training_data': '${{inputs.my_training_data}}',
+        }
+        train_job_outputs = {
+            'model_output': None
+        }
+        train_job = ComponentJob(
+            component=f"TrainLogisticRegressionForRAI:{version_string}",
+            inputs=train_job_inputs,
+            outputs=train_job_outputs
+        )
+
+        # The model registration job
+        register_job_inputs = {
+            'model_input_path': '${{jobs.train-model-job.outputs.model_output}}',
+            'model_base_name': model_name,
+            'model_name_suffix': model_name_suffix
+        }
+        register_job_outputs = {
+            'model_info_output_path': None
+        }
+        register_job = ComponentJob(
+            component=f"RegisterModel:{version_string}",
+            inputs=register_job_inputs,
+            outputs=register_job_outputs
+        )
+
+        # Assemble into a pipeline
+        insights_pipeline_job = PipelineJob(
+            experiment_name=f"Register_Model_{version_string}",
+            description="Python submitted Adult model registration",
+            jobs={
+                'train-model-job': train_job,
+                'register-model-job': register_job,
+            },
+            inputs=pipeline_inputs,
+            outputs=register_job_outputs,
+            compute="cpucluster"
+        )
+
+        # Send it
+        insights_pipeline_job = submit_and_wait(
+            ml_client, insights_pipeline_job)
+        assert insights_pipeline_job is not None
+
+        # Now the pipeline to consume the model
+
+        # The job to fetch the model (this is the one under test)
+        expected_model_id = f'{model_name}_{model_name_suffix}:1'
+        fetch_job_inputs = {
+            'model_id': expected_model_id
+        }
+        fetch_job_outputs = {
+            'model_info_output_path': None
+        }
+        fetch_job = ComponentJob(
+            component=f"FetchRegisteredModel:{version_string}",
+            inputs=fetch_job_inputs,
+            outputs=fetch_job_outputs
+        )
+
+        # Top level RAI Insights component
+        create_rai_inputs = {
+            'title': 'Run built from Python',
+            'task_type': 'classification',
+            'model_info_path': '${{jobs.fetch-model-job.outputs.model_info_output_path}}',
+            'train_dataset': '${{inputs.my_training_data}}',
+            'test_dataset': '${{inputs.my_test_data}}',
+            'target_column_name': '${{inputs.target_column_name}}',
+            'categorical_column_names': '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
+        }
+        create_rai_outputs = {
+            'rai_insights_dashboard': None
+        }
+        create_rai_job = ComponentJob(
+            component=f"RAIInsightsConstructor:{version_string}",
+            inputs=create_rai_inputs,
+            outputs=create_rai_outputs
+        )
+
+        # Setup the explanation
+        explain_inputs = {
+            'comment': 'Insert text here',
+            'rai_insights_dashboard': '${{jobs.create-rai-job.outputs.rai_insights_dashboard}}'
+        }
+        explain_outputs = {
+            'explanation': None
+        }
+        explain_job = ComponentJob(
+            component=f"RAIInsightsExplanation:{version_string}",
+            inputs=explain_inputs,
+            outputs=explain_outputs
+        )
+
+        # Pipeline to construct the RAI Insights
+        insights_pipeline_job = PipelineJob(
+            experiment_name=f"Fetch_Model_for_Insights_{version_string}",
+            description="Python submitted Adult insights using fetched model",
+            jobs={
+                'fetch-model-job': fetch_job,
+                'create-rai-job': create_rai_job,
+                'explain-job': explain_job
+            },
+            inputs=pipeline_inputs,
+            outputs=None,
+            compute="cpucluster"
+        )
+
+        # Send it
+        insights_pipeline_job = submit_and_wait(
+            ml_client, insights_pipeline_job)
+        assert insights_pipeline_job is not None


### PR DESCRIPTION
Users may well have a pretrained and registered model which they want to use in a model analysis. This adds a 'Fetch Registered Model' component to help with this scenario. This takes the id of the desired model, and writes out the JSON file which the RAI Analysis 'constructor' component required.