### PR TITLE
Verify insights came from same constructor

### DIFF
--- a/src/azure-ml-rai/azure_ml_rai/_constants.py
+++ b/src/azure-ml-rai/azure_ml_rai/_constants.py
@@ -11,6 +11,7 @@ class RAIToolType:
     ERROR_ANALYSIS = "error_analysis"
     EXPLANATION = "explanation"
 
+
 class PropertyKeyValues:
     # The property to indicate the type of Run
     RAI_INSIGHTS_TYPE_KEY = "_azureml.responsibleai.rai_insights.type"
@@ -27,4 +28,4 @@ class PropertyKeyValues:
 
 # This comes from the component definitions
 class OutputPortNames:
-    RAI_INSIGHTS_GATHER_RAIINSIGHTS_PORT = 'dashboard'
+    RAI_INSIGHTS_GATHER_RAIINSIGHTS_PORT = "dashboard"

--- a/src/azure-ml-rai/azure_ml_rai/_download_rai_insights.py
+++ b/src/azure-ml-rai/azure_ml_rai/_download_rai_insights.py
@@ -23,19 +23,14 @@ from ._utilities import _get_v1_workspace_client
 
 
 def _get_output_port_info(
-        mlflow_client: MlflowClient,
-        run_id: str,
-        port_name: str) -> Any:
+    mlflow_client: MlflowClient, run_id: str, port_name: str
+) -> Any:
     with tempfile.TemporaryDirectory() as temp_dir:
-        mlflow_client.download_artifacts(
-            run_id,
-            port_name,
-            temp_dir)
+        mlflow_client.download_artifacts(run_id, port_name, temp_dir)
 
-        json_filename = os.path.join(
-            temp_dir, port_name)
+        json_filename = os.path.join(temp_dir, port_name)
 
-        with open(json_filename, 'r') as json_file:
+        with open(json_filename, "r") as json_file:
             port_info = json.load(json_file)
 
     return port_info
@@ -46,38 +41,29 @@ def _download_port_files(
     run_id: str,
     port_name: str,
     target_directory: Path,
-    credential: ChainedTokenCredential
+    credential: ChainedTokenCredential,
 ) -> None:
     port_info = _get_output_port_info(mlflow_client, run_id, port_name)
 
-    wasbs_tuple = AzureBlobArtifactRepository.parse_wasbs_uri(
-        port_info['Uri']
-    )
+    wasbs_tuple = AzureBlobArtifactRepository.parse_wasbs_uri(port_info["Uri"])
     storage_account = wasbs_tuple[1]
     if len(wasbs_tuple) == 4:
         account_dns_suffix = wasbs_tuple[3]
     else:
-        account_dns_suffix = 'blob.core.windows.net'
+        account_dns_suffix = "blob.core.windows.net"
 
     account_url = "https://{account}.{suffix}".format(
-        account=storage_account,
-        suffix=account_dns_suffix
+        account=storage_account, suffix=account_dns_suffix
     )
 
-    bsc = BlobServiceClient(account_url=account_url,
-                            credential=credential)
-    abar = AzureBlobArtifactRepository(
-        port_info['Uri'], client=bsc)
+    bsc = BlobServiceClient(account_url=account_url, credential=credential)
+    abar = AzureBlobArtifactRepository(port_info["Uri"], client=bsc)
 
     # Download everything
-    abar.download_artifacts('', target_directory)
+    abar.download_artifacts("", target_directory)
 
 
-def download_rai_insights(
-    ml_client: MLClient,
-    rai_insight_id: str,
-    path: str
-) -> None:
+def download_rai_insights(ml_client: MLClient, rai_insight_id: str, path: str) -> None:
     v1_ws = _get_v1_workspace_client(ml_client)
 
     mlflow.set_tracking_uri(v1_ws.get_mlflow_tracking_uri())
@@ -92,10 +78,10 @@ def download_rai_insights(
         rai_insight_id,
         OutputPortNames.RAI_INSIGHTS_GATHER_RAIINSIGHTS_PORT,
         output_directory,
-        ml_client._credential
+        ml_client._credential,
     )
 
     # Ensure empty directories are present
-    tool_dirs = ['causal', 'counterfactual', 'error_analysis', 'explainer']
+    tool_dirs = ["causal", "counterfactual", "error_analysis", "explainer"]
     for t in tool_dirs:
         os.makedirs(Path(path) / t, exist_ok=True)

--- a/src/azure-ml-rai/azure_ml_rai/_list_rai_runs.py
+++ b/src/azure-ml-rai/azure_ml_rai/_list_rai_runs.py
@@ -12,9 +12,7 @@ from ._utilities import _get_v1_workspace_client
 
 
 def list_rai_insights(
-    ml_client: MLClient,
-    experiment_name: str,
-    model_id: Optional[str] = None
+    ml_client: MLClient, experiment_name: str, model_id: Optional[str] = None
 ) -> List[str]:
     # Return the Run ids for runs having RAI insights
 
@@ -29,6 +27,7 @@ def list_rai_insights(
     v1_experiment = v1_workspace.experiments[experiment_name]
 
     all_runs = Run.list(
-        v1_experiment, properties=filter_properties, include_children=True)
+        v1_experiment, properties=filter_properties, include_children=True
+    )
 
     return [r.id for r in all_runs]

--- a/src/azure-ml-rai/setup.py
+++ b/src/azure-ml-rai/setup.py
@@ -4,16 +4,12 @@
 
 import setuptools
 
-version = '0.0.1'
-name = 'azure_ml_rai'
+version = "0.0.1"
+name = "azure_ml_rai"
 
 long_description = "Figuring out client side operations for RAI components"
 
-install_requires = [
-    'azure-ml',
-    'azureml-core',
-    'azureml-mlflow'
-]
+install_requires = ["azure-ml", "azureml-core", "azureml-mlflow"]
 
 setuptools.setup(
     name=name,  # noqa: F821
@@ -27,10 +23,10 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     package_data={},
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires=">=3.8",
     install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
-    ]
+    ],
 )

--- a/src/responsibleai/rai_analyse/create_causal.py
+++ b/src/responsibleai/rai_analyse/create_causal.py
@@ -6,10 +6,13 @@ import argparse
 import json
 import logging
 
+from pathlib import Path
+from shutil import copyfile
+
 from responsibleai import RAIInsights
 
 
-from constants import RAIToolType
+from constants import RAIToolType, DashboardInfo
 from rai_component_utilities import (
     load_rai_insights_from_input_port,
     save_to_output_port,
@@ -31,7 +34,8 @@ def parse_args():
 
     parser.add_argument("--rai_insights_dashboard", type=str, required=True)
 
-    parser.add_argument("--treatment_features", type=json.loads, help="List[str]")
+    parser.add_argument("--treatment_features",
+                        type=json.loads, help="List[str]")
     parser.add_argument(
         "--heterogeneity_features",
         type=json.loads,
@@ -65,7 +69,8 @@ def parse_args():
 
 def main(args):
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
+    rai_i: RAIInsights = load_rai_insights_from_input_port(
+        args.rai_insights_dashboard)
 
     # Add the causal analysis
     rai_i.causal.add(
@@ -92,6 +97,14 @@ def main(args):
 
     # Save
     save_to_output_port(rai_i, args.causal_path, RAIToolType.CAUSAL)
+    _logger.info("Saved computation to output port")
+
+    # Copy the dashboard info file
+    dashboard_info_src_path = Path(
+        args.rai_insights_dashboard) / DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
+    dashboard_info_dst_path = Path(
+        args.causal_path) / DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
+    copyfile(dashboard_info_src_path, dashboard_info_dst_path)
 
     _logger.info("Completing")
 

--- a/src/responsibleai/rai_analyse/create_causal.py
+++ b/src/responsibleai/rai_analyse/create_causal.py
@@ -16,7 +16,7 @@ from constants import RAIToolType, DashboardInfo
 from rai_component_utilities import (
     load_rai_insights_from_input_port,
     save_to_output_port,
-    copy_dashboard_info_file
+    copy_dashboard_info_file,
 )
 from arg_helpers import (
     float_or_json_parser,
@@ -35,8 +35,7 @@ def parse_args():
 
     parser.add_argument("--rai_insights_dashboard", type=str, required=True)
 
-    parser.add_argument("--treatment_features",
-                        type=json.loads, help="List[str]")
+    parser.add_argument("--treatment_features", type=json.loads, help="List[str]")
     parser.add_argument(
         "--heterogeneity_features",
         type=json.loads,
@@ -70,8 +69,7 @@ def parse_args():
 
 def main(args):
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(
-        args.rai_insights_dashboard)
+    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
 
     # Add the causal analysis
     rai_i.causal.add(

--- a/src/responsibleai/rai_analyse/create_causal.py
+++ b/src/responsibleai/rai_analyse/create_causal.py
@@ -16,6 +16,7 @@ from constants import RAIToolType, DashboardInfo
 from rai_component_utilities import (
     load_rai_insights_from_input_port,
     save_to_output_port,
+    copy_dashboard_info_file
 )
 from arg_helpers import (
     float_or_json_parser,
@@ -100,11 +101,7 @@ def main(args):
     _logger.info("Saved computation to output port")
 
     # Copy the dashboard info file
-    dashboard_info_src_path = Path(
-        args.rai_insights_dashboard) / DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
-    dashboard_info_dst_path = Path(
-        args.causal_path) / DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
-    copyfile(dashboard_info_src_path, dashboard_info_dst_path)
+    copy_dashboard_info_file(args.rai_insights_dashboard, args.causal_path)
 
     _logger.info("Completing")
 

--- a/src/responsibleai/rai_analyse/create_counterfactual.py
+++ b/src/responsibleai/rai_analyse/create_counterfactual.py
@@ -44,8 +44,7 @@ def parse_args():
 
 def main(args):
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(
-        args.rai_insights_dashboard)
+    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
 
     # Add the counterfactual
     rai_i.counterfactual.add(
@@ -64,13 +63,11 @@ def main(args):
     _logger.info("Computation complete")
 
     # Save
-    save_to_output_port(rai_i, args.counterfactual_path,
-                        RAIToolType.COUNTERFACTUAL)
+    save_to_output_port(rai_i, args.counterfactual_path, RAIToolType.COUNTERFACTUAL)
     _logger.info("Saved to output port")
 
     # Copy the dashboard info file
-    copy_dashboard_info_file(
-        args.rai_insights_dashboard, args.counterfactual_path)
+    copy_dashboard_info_file(args.rai_insights_dashboard, args.counterfactual_path)
 
     _logger.info("Completing")
 

--- a/src/responsibleai/rai_analyse/create_counterfactual.py
+++ b/src/responsibleai/rai_analyse/create_counterfactual.py
@@ -13,6 +13,7 @@ from constants import RAIToolType
 from rai_component_utilities import (
     load_rai_insights_from_input_port,
     save_to_output_port,
+    copy_dashboard_info_file,
 )
 from arg_helpers import boolean_parser, str_or_int_parser, str_or_list_parser
 
@@ -43,7 +44,8 @@ def parse_args():
 
 def main(args):
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
+    rai_i: RAIInsights = load_rai_insights_from_input_port(
+        args.rai_insights_dashboard)
 
     # Add the counterfactual
     rai_i.counterfactual.add(
@@ -62,7 +64,13 @@ def main(args):
     _logger.info("Computation complete")
 
     # Save
-    save_to_output_port(rai_i, args.counterfactual_path, RAIToolType.COUNTERFACTUAL)
+    save_to_output_port(rai_i, args.counterfactual_path,
+                        RAIToolType.COUNTERFACTUAL)
+    _logger.info("Saved to output port")
+
+    # Copy the dashboard info file
+    copy_dashboard_info_file(
+        args.rai_insights_dashboard, args.counterfactual_path)
 
     _logger.info("Completing")
 

--- a/src/responsibleai/rai_analyse/create_error_analysis.py
+++ b/src/responsibleai/rai_analyse/create_error_analysis.py
@@ -13,7 +13,7 @@ from constants import RAIToolType
 from rai_component_utilities import (
     load_rai_insights_from_input_port,
     save_to_output_port,
-    copy_dashboard_info_file
+    copy_dashboard_info_file,
 )
 
 _logger = logging.getLogger(__file__)
@@ -43,8 +43,7 @@ def parse_args():
 
 def main(args):
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(
-        args.rai_insights_dashboard)
+    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
 
     # Add the error analysis
     rai_i.error_analysis.add(
@@ -59,13 +58,11 @@ def main(args):
     _logger.info("Computation complete")
 
     # Save
-    save_to_output_port(rai_i, args.error_analysis_path,
-                        RAIToolType.ERROR_ANALYSIS)
+    save_to_output_port(rai_i, args.error_analysis_path, RAIToolType.ERROR_ANALYSIS)
     _logger.info("Saved to output port")
 
     # Copy the dashboard info file
-    copy_dashboard_info_file(
-        args.rai_insights_dashboard, args.error_analysis_path)
+    copy_dashboard_info_file(args.rai_insights_dashboard, args.error_analysis_path)
 
     _logger.info("Completing")
 

--- a/src/responsibleai/rai_analyse/create_error_analysis.py
+++ b/src/responsibleai/rai_analyse/create_error_analysis.py
@@ -13,6 +13,7 @@ from constants import RAIToolType
 from rai_component_utilities import (
     load_rai_insights_from_input_port,
     save_to_output_port,
+    copy_dashboard_info_file
 )
 
 _logger = logging.getLogger(__file__)
@@ -42,7 +43,8 @@ def parse_args():
 
 def main(args):
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
+    rai_i: RAIInsights = load_rai_insights_from_input_port(
+        args.rai_insights_dashboard)
 
     # Add the error analysis
     rai_i.error_analysis.add(
@@ -57,7 +59,13 @@ def main(args):
     _logger.info("Computation complete")
 
     # Save
-    save_to_output_port(rai_i, args.error_analysis_path, RAIToolType.ERROR_ANALYSIS)
+    save_to_output_port(rai_i, args.error_analysis_path,
+                        RAIToolType.ERROR_ANALYSIS)
+    _logger.info("Saved to output port")
+
+    # Copy the dashboard info file
+    copy_dashboard_info_file(
+        args.rai_insights_dashboard, args.error_analysis_path)
 
     _logger.info("Completing")
 

--- a/src/responsibleai/rai_analyse/create_explanation.py
+++ b/src/responsibleai/rai_analyse/create_explanation.py
@@ -12,6 +12,7 @@ from constants import RAIToolType
 from rai_component_utilities import (
     load_rai_insights_from_input_port,
     save_to_output_port,
+    copy_dashboard_info_file,
 )
 
 _logger = logging.getLogger(__file__)
@@ -35,7 +36,8 @@ def parse_args():
 
 def main(args):
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
+    rai_i: RAIInsights = load_rai_insights_from_input_port(
+        args.rai_insights_dashboard)
 
     # Add the explanation
     rai_i.explainer.add()
@@ -47,6 +49,11 @@ def main(args):
 
     # Save
     save_to_output_port(rai_i, args.explanation_path, RAIToolType.EXPLANATION)
+    _logger.info("Saved to output port")
+
+    # Copy the dashboard info file
+    copy_dashboard_info_file(
+        args.rai_insights_dashboard, args.explanation_path)
 
     _logger.info("Completing")
 

--- a/src/responsibleai/rai_analyse/create_explanation.py
+++ b/src/responsibleai/rai_analyse/create_explanation.py
@@ -36,8 +36,7 @@ def parse_args():
 
 def main(args):
     # Load the RAI Insights object
-    rai_i: RAIInsights = load_rai_insights_from_input_port(
-        args.rai_insights_dashboard)
+    rai_i: RAIInsights = load_rai_insights_from_input_port(args.rai_insights_dashboard)
 
     # Add the explanation
     rai_i.explainer.add()
@@ -52,8 +51,7 @@ def main(args):
     _logger.info("Saved to output port")
 
     # Copy the dashboard info file
-    copy_dashboard_info_file(
-        args.rai_insights_dashboard, args.explanation_path)
+    copy_dashboard_info_file(args.rai_insights_dashboard, args.explanation_path)
 
     _logger.info("Completing")
 

--- a/src/responsibleai/rai_analyse/gather_rai_insights.py
+++ b/src/responsibleai/rai_analyse/gather_rai_insights.py
@@ -22,8 +22,9 @@ from rai_component_utilities import (
     add_properties_to_gather_run,
 )
 
-_DASHBOARD_CONSTRUCTOR_MISMATCH = "Insight {0} was not " \
-    "computed from the constructor specified"
+_DASHBOARD_CONSTRUCTOR_MISMATCH = (
+    "Insight {0} was not " "computed from the constructor specified"
+)
 
 _logger = logging.getLogger(__file__)
 logging.basicConfig(level=logging.INFO)
@@ -75,14 +76,14 @@ def main(args):
                 insight_info = load_dashboard_info_file(Path(ip))
                 _logger.info("Insight info: {0}".format(insight_info))
                 if insight_info != dashboard_info:
-                    err_string = _DASHBOARD_CONSTRUCTOR_MISMATCH.format(i+1)
+                    err_string = _DASHBOARD_CONSTRUCTOR_MISMATCH.format(i + 1)
                     raise ValueError(err_string)
 
-                _logger.info("Copying insight {0}".format(i+1))
+                _logger.info("Copying insight {0}".format(i + 1))
                 tool = copy_insight_to_raiinsights(incoming_dir, Path(ip))
                 included_tools[tool] = True
             else:
-                _logger.info("Insight {0} is None".format(i+1))
+                _logger.info("Insight {0} is None".format(i + 1))
 
         _logger.info("Tool summary: {0}".format(included_tools))
 

--- a/src/responsibleai/rai_analyse/gather_rai_insights.py
+++ b/src/responsibleai/rai_analyse/gather_rai_insights.py
@@ -50,6 +50,7 @@ def parse_args():
 
 def main(args):
     dashboard_info = load_dashboard_info_file(args.constructor)
+    _logger.info("Constructor info: {0}".format(dashboard_info))
 
     with tempfile.TemporaryDirectory() as incoming_temp_dir:
         incoming_dir = Path(incoming_temp_dir)
@@ -72,6 +73,7 @@ def main(args):
             if ip is not None:
                 _logger.info("Checking dashboard info")
                 insight_info = load_dashboard_info_file(Path(ip))
+                _logger.info("Insight info: {0}".format(insight_info))
                 if insight_info != dashboard_info:
                     err_string = _DASHBOARD_CONSTRUCTOR_MISMATCH.format(i+1)
                     raise ValueError(err_string)

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -56,6 +56,12 @@ def load_dashboard_info_file(input_port_path: str) -> Dict[str, str]:
     _logger.info("rai_insights_parent info: {0}".format(dashboard_info))
     return dashboard_info
 
+def copy_dashboard_info_file(src_port_path: str, dst_port_path: str):
+    src = pathlib.Path(src_port_path) / DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
+    dst = pathlib.Path(dst_port_path) / DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
+
+    shutil.copyfile(src, dst)
+
 
 def create_rai_tool_directories(rai_insights_dir: pathlib.Path) -> None:
     # Have to create empty subdirectories for the managers

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -56,6 +56,7 @@ def load_dashboard_info_file(input_port_path: str) -> Dict[str, str]:
     _logger.info("rai_insights_parent info: {0}".format(dashboard_info))
     return dashboard_info
 
+
 def copy_dashboard_info_file(src_port_path: str, dst_port_path: str):
     src = pathlib.Path(src_port_path) / DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
     dst = pathlib.Path(dst_port_path) / DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME

--- a/src/responsibleai/rai_analyse/rai_component_utilities.py
+++ b/src/responsibleai/rai_analyse/rai_component_utilities.py
@@ -91,10 +91,20 @@ def copy_insight_to_raiinsights(
     rai_insights_dir: pathlib.Path, insight_dir: pathlib.Path
 ) -> str:
     print("Starting copy")
-    dir_items = list(insight_dir.iterdir())
-    assert len(dir_items) == 1
 
-    tool_dir_name = dir_items[0].parts[-1]
+    # Recall that we copy the JSON containing metadata from the
+    # constructor component into each directory
+    # This means we have that file and the results directory
+    # present in the insight_dir
+    dir_items = list(insight_dir.iterdir())
+    assert len(dir_items) == 2
+
+    # We want the directory, not the JSON file
+    if dir_items[0].name == DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME:
+        tool_dir_name = dir_items[1].name
+    else:
+        tool_dir_name = dir_items[0].name
+
     _logger.info("Detected tool: {0}".format(tool_dir_name))
     assert tool_dir_name in _tool_directory_mapping.values()
     for k, v in _tool_directory_mapping.items():

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -340,7 +340,7 @@ class TestRAI:
 
         # Assemble into a pipeline
         pipeline_job = PipelineJob(
-            experiment_name=f"Classification_from_Python_{version_string}",
+            experiment_name=f"Gather_Component_Crosscheck_{version_string}",
             description="Python submitted Adult",
             jobs={
                 'train-model-job': train_job,

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -72,7 +72,7 @@ class TestRAI:
 
         submit_and_wait(ml_client, pipeline_job)
 
-    def test_classification_pipeline(self, ml_client: MLClient, component_config):
+    def test_classification_pipeline_from_python(self, ml_client: MLClient, component_config):
         # This is for the Adult dataset
         version_string = component_config['version']
 
@@ -208,7 +208,7 @@ class TestRAI:
 
         # Assemble into a pipeline
         pipeline_job = PipelineJob(
-            experiment_name=f"Classification_from_Python_{version_string}",
+            experiment_name=f"classification_pipeline_from_python_{version_string}",
             description="Python submitted Adult",
             jobs={
                 'train-model-job': train_job,
@@ -351,7 +351,7 @@ class TestRAI:
 
         # Assemble into a pipeline
         pipeline_job = PipelineJob(
-            experiment_name=f"Gather_Component_Crosscheck_{version_string}",
+            experiment_name=f"XFAIL_tool_component_mismatch_{version_string}",
             description="Python submitted Adult",
             jobs={
                 'train-model-job': train_job,
@@ -486,7 +486,7 @@ class TestRAI:
 
         # Pipeline to construct the RAI Insights
         insights_pipeline_job = PipelineJob(
-            experiment_name=f"Fetch_Model_for_Insights_{version_string}",
+            experiment_name=f"fetch_registered_model_component_{version_string}",
             description="Python submitted Adult insights using fetched model",
             jobs={
                 'fetch-model-job': fetch_job,

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -114,8 +114,6 @@ class TestRAI:
             'train_dataset': '${{inputs.my_training_data}}',
             'test_dataset': '${{inputs.my_test_data}}',
             'target_column_name': '${{inputs.target_column_name}}',
-            # 'X_column_names': '["Age", "Workclass", "Education-Num", "Marital Status", "Occupation", "Relationship", "Race", "Sex", "Capital Gain", "Capital Loss", "Hours per week", "Country"]',
-            # 'datastore_name': 'workspaceblobstore',
             'categorical_column_names': '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
         }
         create_rai_outputs = {

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -15,16 +15,18 @@ logging.basicConfig(level=logging.INFO)
 
 
 def process_file(input_file, output_file, replacements):
-    with open(input_file, 'r') as infile, open(output_file, 'w') as outfile:
+    with open(input_file, "r") as infile, open(output_file, "w") as outfile:
         for line in infile:
             for f, r in replacements.items():
                 line = line.replace(f, r)
             outfile.write(line)
 
 
-def submit_and_wait(ml_client: MLClient, pipeline_job: PipelineJob, expected_state: str = 'Completed') -> PipelineJob:
+def submit_and_wait(
+    ml_client: MLClient, pipeline_job: PipelineJob, expected_state: str = "Completed"
+) -> PipelineJob:
     created_job = ml_client.jobs.create_or_update(pipeline_job)
-    terminal_states = ['Completed', 'Failed', 'Canceled', 'NotResponding']
+    terminal_states = ["Completed", "Failed", "Canceled", "NotResponding"]
     assert created_job is not None
     assert expected_state in terminal_states
 
@@ -45,14 +47,10 @@ class TestRAI:
         pipeline_file = current_dir / "pipeline_adult_analyse.yaml"
         pipeline_processed_file = "pipeline_adult_analyse.processed.yaml"
 
-        replacements = {
-            'VERSION_REPLACEMENT_STRING': str(component_config['version'])
-        }
+        replacements = {"VERSION_REPLACEMENT_STRING": str(component_config["version"])}
         process_file(pipeline_file, pipeline_processed_file, replacements)
 
-        pipeline_job = Job.load(
-            path=pipeline_processed_file
-        )
+        pipeline_job = Job.load(path=pipeline_processed_file)
 
         submit_and_wait(ml_client, pipeline_job)
 
@@ -61,149 +59,130 @@ class TestRAI:
         pipeline_file = current_dir / "pipeline_boston_analyse.yaml"
         pipeline_processed_file = "pipeline_boston_analyse.processed.yaml"
 
-        replacements = {
-            'VERSION_REPLACEMENT_STRING': str(component_config['version'])
-        }
+        replacements = {"VERSION_REPLACEMENT_STRING": str(component_config["version"])}
         process_file(pipeline_file, pipeline_processed_file, replacements)
 
-        pipeline_job = Job.load(
-            path=pipeline_processed_file
-        )
+        pipeline_job = Job.load(path=pipeline_processed_file)
 
         submit_and_wait(ml_client, pipeline_job)
 
-    def test_classification_pipeline_from_python(self, ml_client: MLClient, component_config):
+    def test_classification_pipeline_from_python(
+        self, ml_client: MLClient, component_config
+    ):
         # This is for the Adult dataset
-        version_string = component_config['version']
+        version_string = component_config["version"]
 
         # Configure the global pipeline inputs:
         pipeline_inputs = {
-            'target_column_name': 'income',
-            'my_training_data': JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            'my_test_data': JobInput(dataset=f"Adult_Test_PQ:{version_string}")
+            "target_column_name": "income",
+            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
+            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
         }
 
         # Specify the training job
         train_job_inputs = {
-            'target_column_name': '${{inputs.target_column_name}}',
-            'training_data': '${{inputs.my_training_data}}',
+            "target_column_name": "${{inputs.target_column_name}}",
+            "training_data": "${{inputs.my_training_data}}",
         }
-        train_job_outputs = {
-            'model_output': None
-        }
+        train_job_outputs = {"model_output": None}
         train_job = ComponentJob(
             component=f"TrainLogisticRegressionForRAI:{version_string}",
             inputs=train_job_inputs,
-            outputs=train_job_outputs
+            outputs=train_job_outputs,
         )
 
         # The model registration job
         register_job_inputs = {
-            'model_input_path': '${{jobs.train-model-job.outputs.model_output}}',
-            'model_base_name': 'notebook_registered_logreg',
+            "model_input_path": "${{jobs.train-model-job.outputs.model_output}}",
+            "model_base_name": "notebook_registered_logreg",
         }
-        register_job_outputs = {
-            'model_info_output_path': None
-        }
+        register_job_outputs = {"model_info_output_path": None}
         register_job = ComponentJob(
             component=f"RegisterModel:{version_string}",
             inputs=register_job_inputs,
-            outputs=register_job_outputs
+            outputs=register_job_outputs,
         )
 
         # Top level RAI Insights component
         create_rai_inputs = {
-            'title': 'Run built from Python',
-            'task_type': 'classification',
-            'model_info_path': '${{jobs.register-model-job.outputs.model_info_output_path}}',
-            'train_dataset': '${{inputs.my_training_data}}',
-            'test_dataset': '${{inputs.my_test_data}}',
-            'target_column_name': '${{inputs.target_column_name}}',
-            'categorical_column_names': '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
+            "title": "Run built from Python",
+            "task_type": "classification",
+            "model_info_path": "${{jobs.register-model-job.outputs.model_info_output_path}}",
+            "train_dataset": "${{inputs.my_training_data}}",
+            "test_dataset": "${{inputs.my_test_data}}",
+            "target_column_name": "${{inputs.target_column_name}}",
+            "categorical_column_names": '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
         }
-        create_rai_outputs = {
-            'rai_insights_dashboard': None
-        }
+        create_rai_outputs = {"rai_insights_dashboard": None}
         create_rai_job = ComponentJob(
             component=f"RAIInsightsConstructor:{version_string}",
             inputs=create_rai_inputs,
-            outputs=create_rai_outputs
+            outputs=create_rai_outputs,
         )
 
         # Setup the explanation
         explain_inputs = {
-            'comment': 'Insert text here',
-            'rai_insights_dashboard': '${{jobs.create-rai-job.outputs.rai_insights_dashboard}}'
+            "comment": "Insert text here",
+            "rai_insights_dashboard": "${{jobs.create-rai-job.outputs.rai_insights_dashboard}}",
         }
-        explain_outputs = {
-            'explanation': None
-        }
+        explain_outputs = {"explanation": None}
         explain_job = ComponentJob(
             component=f"RAIInsightsExplanation:{version_string}",
             inputs=explain_inputs,
-            outputs=explain_outputs
+            outputs=explain_outputs,
         )
 
         # Setup causal
         causal_inputs = {
-            'rai_insights_dashboard': '${{jobs.create-rai-job.outputs.rai_insights_dashboard}}',
-            'treatment_features': '["Age", "Sex"]',
-            'heterogeneity_features': '["Marital Status"]'
+            "rai_insights_dashboard": "${{jobs.create-rai-job.outputs.rai_insights_dashboard}}",
+            "treatment_features": '["Age", "Sex"]',
+            "heterogeneity_features": '["Marital Status"]',
         }
-        causal_outputs = {
-            'causal': None
-        }
+        causal_outputs = {"causal": None}
         causal_job = ComponentJob(
             component=f"RAIInsightsCausal:{version_string}",
             inputs=causal_inputs,
-            outputs=causal_outputs
+            outputs=causal_outputs,
         )
 
         # Setup counterfactual
         counterfactual_inputs = {
-            'rai_insights_dashboard': '${{jobs.create-rai-job.outputs.rai_insights_dashboard}}',
-            'total_CFs': '10',
-            'desired_class': 'opposite'
+            "rai_insights_dashboard": "${{jobs.create-rai-job.outputs.rai_insights_dashboard}}",
+            "total_CFs": "10",
+            "desired_class": "opposite",
         }
-        counterfactual_outputs = {
-            'counterfactual': None
-        }
+        counterfactual_outputs = {"counterfactual": None}
         counterfactual_job = ComponentJob(
             component=f"RAIInsightsCounterfactual:{version_string}",
             inputs=counterfactual_inputs,
-            outputs=counterfactual_outputs
+            outputs=counterfactual_outputs,
         )
 
         # Setup error analysis
         error_analysis_inputs = {
-            'rai_insights_dashboard': '${{jobs.create-rai-job.outputs.rai_insights_dashboard}}',
-            'filter_features': '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
+            "rai_insights_dashboard": "${{jobs.create-rai-job.outputs.rai_insights_dashboard}}",
+            "filter_features": '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
         }
-        error_analysis_outputs = {
-            'error_analysis': None
-        }
+        error_analysis_outputs = {"error_analysis": None}
         error_analysis_job = ComponentJob(
             component=f"RAIInsightsErrorAnalysis:{version_string}",
             inputs=error_analysis_inputs,
-            outputs=error_analysis_outputs
+            outputs=error_analysis_outputs,
         )
 
         # Configure the gather component
         gather_inputs = {
-            'constructor': '${{jobs.create-rai-job.outputs.rai_insights_dashboard}}',
+            "constructor": "${{jobs.create-rai-job.outputs.rai_insights_dashboard}}",
             # 'insight_1': '${{jobs.explain-rai-job.outputs.explanation}}',
-            'insight_2': '${{jobs.causal-rai-job.outputs.causal}}',
-            'insight_3': '${{jobs.counterfactual-rai-job.outputs.counterfactual}}',
-            'insight_4': '${{jobs.error-analysis-rai-job.outputs.error_analysis}}'
+            "insight_2": "${{jobs.causal-rai-job.outputs.causal}}",
+            "insight_3": "${{jobs.counterfactual-rai-job.outputs.counterfactual}}",
+            "insight_4": "${{jobs.error-analysis-rai-job.outputs.error_analysis}}",
         }
-        gather_outputs = {
-            'dashboard': None,
-            'ux_json': None
-        }
+        gather_outputs = {"dashboard": None, "ux_json": None}
         gather_job = ComponentJob(
             component=f"RAIInsightsGather:{version_string}",
             inputs=gather_inputs,
-            outputs=gather_outputs
+            outputs=gather_outputs,
         )
 
         # Assemble into a pipeline
@@ -211,18 +190,18 @@ class TestRAI:
             experiment_name=f"classification_pipeline_from_python_{version_string}",
             description="Python submitted Adult",
             jobs={
-                'train-model-job': train_job,
-                'register-model-job': register_job,
-                'create-rai-job': create_rai_job,
-                'explain-rai-job': explain_job,
-                'causal-rai-job': causal_job,
-                'counterfactual-rai-job': counterfactual_job,
-                'error-analysis-rai-job': error_analysis_job,
-                'gather-job': gather_job
+                "train-model-job": train_job,
+                "register-model-job": register_job,
+                "create-rai-job": create_rai_job,
+                "explain-rai-job": explain_job,
+                "causal-rai-job": causal_job,
+                "counterfactual-rai-job": counterfactual_job,
+                "error-analysis-rai-job": error_analysis_job,
+                "gather-job": gather_job,
             },
             inputs=pipeline_inputs,
             outputs=train_job_outputs,
-            compute="cpucluster"
+            compute="cpucluster",
         )
 
         # Send it
@@ -232,121 +211,110 @@ class TestRAI:
     def test_tool_component_mismatch(self, ml_client: MLClient, component_config):
         # Checks that components from different constructors can't be mixed
         # This is for the Adult dataset
-        version_string = component_config['version']
+        version_string = component_config["version"]
 
         # Configure the global pipeline inputs:
         pipeline_inputs = {
-            'target_column_name': 'income',
-            'my_training_data': JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            'my_test_data': JobInput(dataset=f"Adult_Test_PQ:{version_string}")
+            "target_column_name": "income",
+            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
+            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
         }
 
         # Specify the training job
         train_job_inputs = {
-            'target_column_name': '${{inputs.target_column_name}}',
-            'training_data': '${{inputs.my_training_data}}',
+            "target_column_name": "${{inputs.target_column_name}}",
+            "training_data": "${{inputs.my_training_data}}",
         }
-        train_job_outputs = {
-            'model_output': None
-        }
+        train_job_outputs = {"model_output": None}
         train_job = ComponentJob(
             component=f"TrainLogisticRegressionForRAI:{version_string}",
             inputs=train_job_inputs,
-            outputs=train_job_outputs
+            outputs=train_job_outputs,
         )
 
         # The model registration job
         register_job_inputs = {
-            'model_input_path': '${{jobs.train-model-job.outputs.model_output}}',
-            'model_base_name': 'notebook_registered_logreg',
+            "model_input_path": "${{jobs.train-model-job.outputs.model_output}}",
+            "model_base_name": "notebook_registered_logreg",
         }
-        register_job_outputs = {
-            'model_info_output_path': None
-        }
+        register_job_outputs = {"model_info_output_path": None}
         # Register twice (the component is non-deterministic so we can be
         # sure output won't be reused)
         register_job_1 = ComponentJob(
             component=f"RegisterModel:{version_string}",
             inputs=register_job_inputs,
-            outputs=register_job_outputs
+            outputs=register_job_outputs,
         )
         register_job_2 = ComponentJob(
             component=f"RegisterModel:{version_string}",
             inputs=register_job_inputs,
-            outputs=register_job_outputs
+            outputs=register_job_outputs,
         )
 
         # Top level RAI Insights component
         create_rai_inputs = {
-            'title': 'Run built from Python',
-            'task_type': 'classification',
-            'model_info_path': '${{jobs.register-model-job-1.outputs.model_info_output_path}}',
-            'train_dataset': '${{inputs.my_training_data}}',
-            'test_dataset': '${{inputs.my_test_data}}',
-            'target_column_name': '${{inputs.target_column_name}}',
-            'categorical_column_names': '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
+            "title": "Run built from Python",
+            "task_type": "classification",
+            "model_info_path": "${{jobs.register-model-job-1.outputs.model_info_output_path}}",
+            "train_dataset": "${{inputs.my_training_data}}",
+            "test_dataset": "${{inputs.my_test_data}}",
+            "target_column_name": "${{inputs.target_column_name}}",
+            "categorical_column_names": '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
         }
-        create_rai_outputs = {
-            'rai_insights_dashboard': None
-        }
+        create_rai_outputs = {"rai_insights_dashboard": None}
 
         # Have TWO dashboard constructors
         create_rai_1 = ComponentJob(
             component=f"RAIInsightsConstructor:{version_string}",
             inputs=create_rai_inputs,
-            outputs=create_rai_outputs
+            outputs=create_rai_outputs,
         )
-        create_rai_inputs['model_info_path'] = '${{jobs.register-model-job-2.outputs.model_info_output_path}}'
+        create_rai_inputs[
+            "model_info_path"
+        ] = "${{jobs.register-model-job-2.outputs.model_info_output_path}}"
         create_rai_2 = ComponentJob(
             component=f"RAIInsightsConstructor:{version_string}",
             inputs=create_rai_inputs,
-            outputs=create_rai_outputs
+            outputs=create_rai_outputs,
         )
 
         # Setup causal on constructor 1
         causal_inputs = {
-            'rai_insights_dashboard': '${{jobs.create-rai-job-1.outputs.rai_insights_dashboard}}',
-            'treatment_features': '["Age", "Sex"]',
-            'heterogeneity_features': '["Marital Status"]'
+            "rai_insights_dashboard": "${{jobs.create-rai-job-1.outputs.rai_insights_dashboard}}",
+            "treatment_features": '["Age", "Sex"]',
+            "heterogeneity_features": '["Marital Status"]',
         }
-        causal_outputs = {
-            'causal': None
-        }
+        causal_outputs = {"causal": None}
         causal_job = ComponentJob(
             component=f"RAIInsightsCausal:{version_string}",
             inputs=causal_inputs,
-            outputs=causal_outputs
+            outputs=causal_outputs,
         )
 
         # Setup counterfactual on constructor 2
         counterfactual_inputs = {
-            'rai_insights_dashboard': '${{jobs.create-rai-job-2.outputs.rai_insights_dashboard}}',
-            'total_CFs': '10',
-            'desired_class': 'opposite'
+            "rai_insights_dashboard": "${{jobs.create-rai-job-2.outputs.rai_insights_dashboard}}",
+            "total_CFs": "10",
+            "desired_class": "opposite",
         }
-        counterfactual_outputs = {
-            'counterfactual': None
-        }
+        counterfactual_outputs = {"counterfactual": None}
         counterfactual_job = ComponentJob(
             component=f"RAIInsightsCounterfactual:{version_string}",
             inputs=counterfactual_inputs,
-            outputs=counterfactual_outputs
+            outputs=counterfactual_outputs,
         )
 
         # Configure the gather component
         gather_inputs = {
-            'constructor': '${{jobs.create-rai-job-1.outputs.rai_insights_dashboard}}',
-            'insight_2': '${{jobs.causal-rai-job.outputs.causal}}',
-            'insight_3': '${{jobs.counterfactual-rai-job.outputs.counterfactual}}',
+            "constructor": "${{jobs.create-rai-job-1.outputs.rai_insights_dashboard}}",
+            "insight_2": "${{jobs.causal-rai-job.outputs.causal}}",
+            "insight_3": "${{jobs.counterfactual-rai-job.outputs.counterfactual}}",
         }
-        gather_outputs = {
-            'dashboard': None,
-            'ux_json': None
-        }
+        gather_outputs = {"dashboard": None, "ux_json": None}
         gather_job = ComponentJob(
             component=f"RAIInsightsGather:{version_string}",
             inputs=gather_inputs,
-            outputs=gather_outputs
+            outputs=gather_outputs,
         )
 
         # Assemble into a pipeline
@@ -354,67 +322,63 @@ class TestRAI:
             experiment_name=f"XFAIL_tool_component_mismatch_{version_string}",
             description="Python submitted Adult",
             jobs={
-                'train-model-job': train_job,
-                'register-model-job-1': register_job_1,
-                'register-model-job-2': register_job_2,
-                'create-rai-job-1': create_rai_1,
-                'create-rai-job-2': create_rai_2,
-                'causal-rai-job': causal_job,
-                'counterfactual-rai-job': counterfactual_job,
-                'gather-job': gather_job
+                "train-model-job": train_job,
+                "register-model-job-1": register_job_1,
+                "register-model-job-2": register_job_2,
+                "create-rai-job-1": create_rai_1,
+                "create-rai-job-2": create_rai_2,
+                "causal-rai-job": causal_job,
+                "counterfactual-rai-job": counterfactual_job,
+                "gather-job": gather_job,
             },
             inputs=pipeline_inputs,
             outputs=train_job_outputs,
-            compute="cpucluster"
+            compute="cpucluster",
         )
 
         # Send it
-        pipeline_job = submit_and_wait(ml_client, pipeline_job, 'Failed')
+        pipeline_job = submit_and_wait(ml_client, pipeline_job, "Failed")
         # Want to do more here, but there isn't anything useful in the returned job
         # Problem is, the job might have failed for some other reason
         assert pipeline_job is not None
 
     def test_fetch_registered_model_component(self, ml_client, component_config):
         # Actually does two pipelines. One to register, then one to use
-        version_string = component_config['version']
+        version_string = component_config["version"]
 
         model_name_suffix = int(time.time())
-        model_name = 'fetch_model'
+        model_name = "fetch_model"
 
         # Configure the global pipeline inputs:
         pipeline_inputs = {
-            'target_column_name': 'income',
-            'my_training_data': JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
-            'my_test_data': JobInput(dataset=f"Adult_Test_PQ:{version_string}")
+            "target_column_name": "income",
+            "my_training_data": JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
+            "my_test_data": JobInput(dataset=f"Adult_Test_PQ:{version_string}"),
         }
 
         # Specify the training job
         train_job_inputs = {
-            'target_column_name': '${{inputs.target_column_name}}',
-            'training_data': '${{inputs.my_training_data}}',
+            "target_column_name": "${{inputs.target_column_name}}",
+            "training_data": "${{inputs.my_training_data}}",
         }
-        train_job_outputs = {
-            'model_output': None
-        }
+        train_job_outputs = {"model_output": None}
         train_job = ComponentJob(
             component=f"TrainLogisticRegressionForRAI:{version_string}",
             inputs=train_job_inputs,
-            outputs=train_job_outputs
+            outputs=train_job_outputs,
         )
 
         # The model registration job
         register_job_inputs = {
-            'model_input_path': '${{jobs.train-model-job.outputs.model_output}}',
-            'model_base_name': model_name,
-            'model_name_suffix': model_name_suffix
+            "model_input_path": "${{jobs.train-model-job.outputs.model_output}}",
+            "model_base_name": model_name,
+            "model_name_suffix": model_name_suffix,
         }
-        register_job_outputs = {
-            'model_info_output_path': None
-        }
+        register_job_outputs = {"model_info_output_path": None}
         register_job = ComponentJob(
             component=f"RegisterModel:{version_string}",
             inputs=register_job_inputs,
-            outputs=register_job_outputs
+            outputs=register_job_outputs,
         )
 
         # Assemble into a pipeline
@@ -422,66 +386,57 @@ class TestRAI:
             experiment_name=f"Register_Model_{version_string}",
             description="Python submitted Adult model registration",
             jobs={
-                'train-model-job': train_job,
-                'register-model-job': register_job,
+                "train-model-job": train_job,
+                "register-model-job": register_job,
             },
             inputs=pipeline_inputs,
             outputs=register_job_outputs,
-            compute="cpucluster"
+            compute="cpucluster",
         )
 
         # Send it
-        register_pipeline_job = submit_and_wait(
-            ml_client, register_pipeline)
+        register_pipeline_job = submit_and_wait(ml_client, register_pipeline)
         assert register_pipeline_job is not None
 
         # Now the pipeline to consume the model
 
         # The job to fetch the model (this is the one under test)
-        expected_model_id = f'{model_name}_{model_name_suffix}:1'
-        fetch_job_inputs = {
-            'model_id': expected_model_id
-        }
-        fetch_job_outputs = {
-            'model_info_output_path': None
-        }
+        expected_model_id = f"{model_name}_{model_name_suffix}:1"
+        fetch_job_inputs = {"model_id": expected_model_id}
+        fetch_job_outputs = {"model_info_output_path": None}
         fetch_job = ComponentJob(
             component=f"FetchRegisteredModel:{version_string}",
             inputs=fetch_job_inputs,
-            outputs=fetch_job_outputs
+            outputs=fetch_job_outputs,
         )
 
         # Top level RAI Insights component
         create_rai_inputs = {
-            'title': 'Run built from Python',
-            'task_type': 'classification',
-            'model_info_path': '${{jobs.fetch-model-job.outputs.model_info_output_path}}',
-            'train_dataset': '${{inputs.my_training_data}}',
-            'test_dataset': '${{inputs.my_test_data}}',
-            'target_column_name': '${{inputs.target_column_name}}',
-            'categorical_column_names': '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
+            "title": "Run built from Python",
+            "task_type": "classification",
+            "model_info_path": "${{jobs.fetch-model-job.outputs.model_info_output_path}}",
+            "train_dataset": "${{inputs.my_training_data}}",
+            "test_dataset": "${{inputs.my_test_data}}",
+            "target_column_name": "${{inputs.target_column_name}}",
+            "categorical_column_names": '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
         }
-        create_rai_outputs = {
-            'rai_insights_dashboard': None
-        }
+        create_rai_outputs = {"rai_insights_dashboard": None}
         create_rai_job = ComponentJob(
             component=f"RAIInsightsConstructor:{version_string}",
             inputs=create_rai_inputs,
-            outputs=create_rai_outputs
+            outputs=create_rai_outputs,
         )
 
         # Setup the explanation
         explain_inputs = {
-            'comment': 'Insert text here',
-            'rai_insights_dashboard': '${{jobs.create-rai-job.outputs.rai_insights_dashboard}}'
+            "comment": "Insert text here",
+            "rai_insights_dashboard": "${{jobs.create-rai-job.outputs.rai_insights_dashboard}}",
         }
-        explain_outputs = {
-            'explanation': None
-        }
+        explain_outputs = {"explanation": None}
         explain_job = ComponentJob(
             component=f"RAIInsightsExplanation:{version_string}",
             inputs=explain_inputs,
-            outputs=explain_outputs
+            outputs=explain_outputs,
         )
 
         # Pipeline to construct the RAI Insights
@@ -489,16 +444,15 @@ class TestRAI:
             experiment_name=f"fetch_registered_model_component_{version_string}",
             description="Python submitted Adult insights using fetched model",
             jobs={
-                'fetch-model-job': fetch_job,
-                'create-rai-job': create_rai_job,
-                'explain-job': explain_job
+                "fetch-model-job": fetch_job,
+                "create-rai-job": create_rai_job,
+                "explain-job": explain_job,
             },
             inputs=pipeline_inputs,
             outputs=None,
-            compute="cpucluster"
+            compute="cpucluster",
         )
 
         # Send it
-        insights_pipeline_job = submit_and_wait(
-            ml_client, insights_pipeline_job)
+        insights_pipeline_job = submit_and_wait(ml_client, insights_pipeline_job)
         assert insights_pipeline_job is not None

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -30,6 +30,8 @@ def submit_and_wait(ml_client, pipeline_job) -> PipelineJob:
         created_job = ml_client.jobs.get(created_job.name)
         print("Latest status : {0}".format(created_job.status))
         _logger.info("Latest status : {0}".format(created_job.status))
+    if created_job.status != 'Completed':
+        _logger.error(str(created_job))
     assert created_job.status == 'Completed'
     return created_job
 
@@ -224,6 +226,141 @@ class TestRAI:
         pipeline_job = submit_and_wait(ml_client, pipeline_job)
         assert pipeline_job is not None
 
+    def test_tool_component_mismatch(self, ml_client, component_config):
+        # Checks that components from different constructors can't be mixed
+        # This is for the Adult dataset
+        version_string = component_config['version']
+
+        # Configure the global pipeline inputs:
+        pipeline_inputs = {
+            'target_column_name': 'income',
+            'my_training_data': JobInput(dataset=f"Adult_Train_PQ:{version_string}"),
+            'my_test_data': JobInput(dataset=f"Adult_Test_PQ:{version_string}")
+        }
+
+        # Specify the training job
+        train_job_inputs = {
+            'target_column_name': '${{inputs.target_column_name}}',
+            'training_data': '${{inputs.my_training_data}}',
+        }
+        train_job_outputs = {
+            'model_output': None
+        }
+        train_job = ComponentJob(
+            component=f"TrainLogisticRegressionForRAI:{version_string}",
+            inputs=train_job_inputs,
+            outputs=train_job_outputs
+        )
+
+        # The model registration job
+        register_job_inputs = {
+            'model_input_path': '${{jobs.train-model-job.outputs.model_output}}',
+            'model_base_name': 'notebook_registered_logreg',
+        }
+        register_job_outputs = {
+            'model_info_output_path': None
+        }
+        register_job = ComponentJob(
+            component=f"RegisterModel:{version_string}",
+            inputs=register_job_inputs,
+            outputs=register_job_outputs
+        )
+
+        # Top level RAI Insights component
+        create_rai_inputs = {
+            'title': 'Run built from Python',
+            'task_type': 'classification',
+            'model_info_path': '${{jobs.register-model-job.outputs.model_info_output_path}}',
+            'train_dataset': '${{inputs.my_training_data}}',
+            'test_dataset': '${{inputs.my_test_data}}',
+            'target_column_name': '${{inputs.target_column_name}}',
+            'categorical_column_names': '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]',
+        }
+        create_rai_outputs = {
+            'rai_insights_dashboard': None
+        }
+
+        # Have TWO dashboard constructors
+        create_rai_1 = ComponentJob(
+            component=f"RAIInsightsConstructor:{version_string}",
+            inputs=create_rai_inputs,
+            outputs=create_rai_outputs
+        )
+        create_rai_2 = ComponentJob(
+            component=f"RAIInsightsConstructor:{version_string}",
+            inputs=create_rai_inputs,
+            outputs=create_rai_outputs
+        )
+
+        # Setup causal on constructor 1
+        causal_inputs = {
+            'rai_insights_dashboard': '${{jobs.create-rai-job-1.outputs.rai_insights_dashboard}}',
+            'treatment_features': '["Age", "Sex"]',
+            'heterogeneity_features': '["Marital Status"]'
+        }
+        causal_outputs = {
+            'causal': None
+        }
+        causal_job = ComponentJob(
+            component=f"RAIInsightsCausal:{version_string}",
+            inputs=causal_inputs,
+            outputs=causal_outputs
+        )
+
+        # Setup counterfactual on constructor 2
+        counterfactual_inputs = {
+            'rai_insights_dashboard': '${{jobs.create-rai-job-2.outputs.rai_insights_dashboard}}',
+            'total_CFs': '10',
+            'desired_class': 'opposite'
+        }
+        counterfactual_outputs = {
+            'counterfactual': None
+        }
+        counterfactual_job = ComponentJob(
+            component=f"RAIInsightsCounterfactual:{version_string}",
+            inputs=counterfactual_inputs,
+            outputs=counterfactual_outputs
+        )
+
+        # Configure the gather component
+        gather_inputs = {
+            'constructor': '${{jobs.create-rai-job-1.outputs.rai_insights_dashboard}}',
+            'insight_2': '${{jobs.causal-rai-job.outputs.causal}}',
+            'insight_3': '${{jobs.counterfactual-rai-job.outputs.counterfactual}}',
+        }
+        gather_outputs = {
+            'dashboard': None,
+            'ux_json': None
+        }
+        gather_job = ComponentJob(
+            component=f"RAIInsightsGather:{version_string}",
+            inputs=gather_inputs,
+            outputs=gather_outputs
+        )
+
+        # Assemble into a pipeline
+        pipeline_job = PipelineJob(
+            experiment_name=f"Classification_from_Python_{version_string}",
+            description="Python submitted Adult",
+            jobs={
+                'train-model-job': train_job,
+                'register-model-job': register_job,
+                'create-rai-job-1': create_rai_1,
+                'create-rai-job-2': create_rai_2,
+                'causal-rai-job': causal_job,
+                'counterfactual-rai-job': counterfactual_job,
+                'gather-job': gather_job
+            },
+            inputs=pipeline_inputs,
+            outputs=train_job_outputs,
+            compute="cpucluster"
+        )
+
+        # Send it
+        pipeline_job = submit_and_wait(ml_client, pipeline_job)
+        assert pipeline_job is not None
+
+
     def test_fetch_registered_model_component(self, ml_client, component_config):
         # Actually does two pipelines. One to register, then one to use
         version_string = component_config['version']
@@ -268,7 +405,7 @@ class TestRAI:
         )
 
         # Assemble into a pipeline
-        insights_pipeline_job = PipelineJob(
+        register_pipeline = PipelineJob(
             experiment_name=f"Register_Model_{version_string}",
             description="Python submitted Adult model registration",
             jobs={
@@ -281,9 +418,9 @@ class TestRAI:
         )
 
         # Send it
-        insights_pipeline_job = submit_and_wait(
-            ml_client, insights_pipeline_job)
-        assert insights_pipeline_job is not None
+        register_pipeline_job = submit_and_wait(
+            ml_client, register_pipeline)
+        assert register_pipeline_job is not None
 
         # Now the pipeline to consume the model
 


### PR DESCRIPTION
Add a check to ensure that all the insights being assembled came from the same constructor. This includes a test which runs a pipeline which is expected to fail. Unfortunately, there is not currently a good way of checking _why_ the pipeline failed.

Also, rerun `black` on the affected files