### PR TITLE
Update responsibleai and connect Gather components

### DIFF
--- a/src/responsibleai/conda_envs/python-aml-rai.yaml
+++ b/src/responsibleai/conda_envs/python-aml-rai.yaml
@@ -10,5 +10,5 @@ dependencies:
     - pyarrow
     - scikit-learn
     - mlflow
-    - azureml-mlflow~=1.35.0
-    - responsibleai~=0.15.1
+    - azureml-mlflow~=1.37.0
+    - responsibleai~=0.16.0

--- a/test/rai/pipeline_adult_analyse.yaml
+++ b/test/rai/pipeline_adult_analyse.yaml
@@ -92,3 +92,13 @@ jobs:
     inputs:
       rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
       filter_features: '["Race", "Sex", "Workclass", "Marital Status", "Country", "Occupation"]'
+
+  gather_01:
+    type: component_job
+    component: azureml:RAIInsightsGather:VERSION_REPLACEMENT_STRING
+    inputs:
+      constructor: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      insight_1: ${{jobs.causal_01.outputs.causal}}
+      insight_2: ${{jobs.counterfactual_01.outputs.counterfactual}}
+      insight_3: ${{jobs.error_analysis_01.outputs.error_analysis}}
+      insight_4: ${{jobs.explain_01.outputs.explanation}}

--- a/test/rai/pipeline_boston_analyse.yaml
+++ b/test/rai/pipeline_boston_analyse.yaml
@@ -99,3 +99,14 @@ jobs:
       rai_insights_dashboard: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
       max_depth: 3
       filter_features: '[]'
+
+  
+  gather_01:
+    type: component_job
+    component: azureml:RAIInsightsGather:VERSION_REPLACEMENT_STRING
+    inputs:
+      constructor: ${{jobs.create-rai-job.outputs.rai_insights_dashboard}}
+      insight_1: ${{jobs.causal_01.outputs.causal}}
+      insight_2: ${{jobs.counterfactual_01.outputs.counterfactual}}
+      insight_3: ${{jobs.error_analysis_01.outputs.error_analysis}}
+      insight_4: ${{jobs.explain_01.outputs.explanation}}

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -439,6 +439,18 @@ class TestRAI:
             outputs=explain_outputs,
         )
 
+        # Configure the gather component
+        gather_inputs = {
+            "constructor": "${{jobs.create-rai-job.outputs.rai_insights_dashboard}}",
+            "insight_1": "${{jobs.explain-rai-job.outputs.explanation}}",
+        }
+        gather_outputs = {"dashboard": None, "ux_json": None}
+        gather_job = ComponentJob(
+            component=f"RAIInsightsGather:{version_string}",
+            inputs=gather_inputs,
+            outputs=gather_outputs,
+        )
+
         # Pipeline to construct the RAI Insights
         insights_pipeline_job = PipelineJob(
             experiment_name=f"fetch_registered_model_component_{version_string}",
@@ -447,6 +459,7 @@ class TestRAI:
                 "fetch-model-job": fetch_job,
                 "create-rai-job": create_rai_job,
                 "explain-job": explain_job,
+                "gather-job": gather_job,
             },
             inputs=pipeline_inputs,
             outputs=None,

--- a/test/rai/test_rai_pipeline.py
+++ b/test/rai/test_rai_pipeline.py
@@ -173,7 +173,7 @@ class TestRAI:
         # Configure the gather component
         gather_inputs = {
             "constructor": "${{jobs.create-rai-job.outputs.rai_insights_dashboard}}",
-            # 'insight_1': '${{jobs.explain-rai-job.outputs.explanation}}',
+            "insight_1": "${{jobs.explain-rai-job.outputs.explanation}}",
             "insight_2": "${{jobs.causal-rai-job.outputs.causal}}",
             "insight_3": "${{jobs.counterfactual-rai-job.outputs.counterfactual}}",
             "insight_4": "${{jobs.error-analysis-rai-job.outputs.error_analysis}}",


### PR DESCRIPTION
Update the `responsibleai` package to the latest release, which fixes a problem with explanations. Put `Gather` components, with connected explanations into the tests.