### PR TITLE
Remove .NET references from Powershell script

### DIFF
--- a/scripts/Register-AzureML.ps1
+++ b/scripts/Register-AzureML.ps1
@@ -170,7 +170,7 @@ function Process-Directory(
     Write-Host
 
     foreach ($directory in $reg_config.nested_directories){
-        $nxt_dir = [System.IO.Path]::Join($base_directory, $directory)
+        $nxt_dir = Join-Path -Path $base_directory -ChildPath $directory
         Write-Host "Recursing into $nxt_dir"
         Process-Directory -workspace_config $workspace_config `
                         -component_config $component_config `

--- a/scripts/Register-AzureML.ps1
+++ b/scripts/Register-AzureML.ps1
@@ -128,7 +128,7 @@ function Process-Directory(
 )
 {
     Write-Host "Processing directory: $base_directory"
-    $reg_config_file = [System.IO.Path]::Join($base_directory, 'registration_config.json')
+    $reg_config_file = Join-Path -Path $base_directory -ChildPath 'registration_config.json'
     $reg_config = Read-JsonConfig($reg_config_file)
 
     # Register the environments


### PR DESCRIPTION
For some reason, calls to `[System.IO.Path]::Join` were not working when running the registration script locally (the builds didn't care). Remove them in favour of the `Join-Path` cmdlet.